### PR TITLE
カード移動機能を作成

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,6 +1,8 @@
 class CardsController < ApplicationController
-  before_action :set_project, only: %i[new create]
-  before_action :set_column, only: %i[new create]
+  before_action :set_myproject, only: %i[new create]
+  before_action :set_project, only: %i[edit update destroy]
+  before_action :set_column
+  before_action :set_card, only: %i[edit update destroy]
 
   def new
     @card = @column.cards.build
@@ -19,17 +21,45 @@ class CardsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @card.update(card_params)
+      redirect_to project_path(@project), notice: 'カードを更新しました'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @card.destroy
+      redirect_to project_path(@project), notice: 'カードを削除しました'
+    else
+      flash.now[:alert] = 'カードの削除に失敗しました。'
+      render :edit
+    end
+  end
+
   private
 
   def card_params
     params.require(:card).permit(:name, :due_date, :assignee_id)
   end
 
-  def set_project
+  def set_myproject
     @project = current_user.projects.find(params[:project_id])
+  end
+
+  def set_project
+    @project = Project.accessible(current_user).find(params[:project_id])
   end
 
   def set_column
     @column = @project.columns.find(params[:column_id])
+  end
+
+  def set_card
+    @card = @column.cards.find(params[:id])
   end
 end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,0 +1,35 @@
+class CardsController < ApplicationController
+  before_action :set_project, only: %i[new create]
+  before_action :set_column, only: %i[new create]
+
+  def new
+    @card = @column.cards.build
+    @card.project = @project
+    @card.assignee = current_user
+  end
+
+  def create
+    @card = @column.cards.build(card_params)
+    @card.project = @project
+
+    if @card.save
+      redirect_to project_path(@project), notice: 'カードを作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def card_params
+    params.require(:card).permit(:name, :due_date, :assignee_id)
+  end
+
+  def set_project
+    @project = current_user.projects.find(params[:project_id])
+  end
+
+  def set_column
+    @column = @project.columns.find(params[:column_id])
+  end
+end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,8 +1,8 @@
 class CardsController < ApplicationController
   before_action :set_myproject, only: %i[new create]
-  before_action :set_project, only: %i[edit update destroy]
+  before_action :set_project, only: %i[edit update destroy previous next]
   before_action :set_column
-  before_action :set_card, only: %i[edit update destroy]
+  before_action :set_card, only: %i[edit update destroy previous next]
 
   def new
     @card = @column.cards.build
@@ -39,6 +39,18 @@ class CardsController < ApplicationController
       flash.now[:alert] = 'カードの削除に失敗しました。'
       render :edit
     end
+  end
+
+  def previous
+    @card.column = @column.higher_item
+    @card.save
+    redirect_to project_path(@project)
+  end
+
+  def next
+    @card.column = @column.lower_item
+    @card.save
+    redirect_to project_path(@project)
   end
 
   private

--- a/app/controllers/columns_controller.rb
+++ b/app/controllers/columns_controller.rb
@@ -1,6 +1,7 @@
 class ColumnsController < ApplicationController
   before_action :set_project
   before_action :set_column, only: %i[edit update destroy previous next]
+
   def new
     @column = @project.columns.build
   end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -5,6 +5,8 @@ class Card < ApplicationRecord
   belongs_to :project
   belongs_to :column
 
+  acts_as_list scope: %i[project_id column_id]
+
   validates :name, presence: true,
                    uniqueness: { scope: :project },
                    length: { maximum: 40 }

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,0 +1,12 @@
+class Card < ApplicationRecord
+  belongs_to :assignee, class_name: 'User',
+                        foreign_key: :assignee_id,
+                        inverse_of: :assigned_cards
+  belongs_to :project
+  belongs_to :column
+
+  validates :name, presence: true,
+                   uniqueness: { scope: :project },
+                   length: { maximum: 40 }
+  validates :due_date, allow_nil: true, due_date_range: true
+end

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -1,5 +1,7 @@
 class Column < ApplicationRecord
   belongs_to :project
+  has_many :cards, dependent: :destroy
+
   acts_as_list scope: :project
 
   validates :name, presence: true, uniqueness: { scope: :project }, length: { maximum: 40 }

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -1,6 +1,6 @@
 class Column < ApplicationRecord
   belongs_to :project
-  has_many :cards, dependent: :destroy
+  has_many :cards, -> { order(position: :desc) }, dependent: :destroy
 
   acts_as_list scope: :project
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
   belongs_to :user
   has_many :columns, -> { order(position: :asc) }, dependent: :destroy
+  has_many :cards, dependent: :destroy
 
   COUNT_FOR_FIRST_PAGE = 8
   COUNT_FOR_OTHER_PAGE = 9

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,10 @@ class User < ApplicationRecord
   mount_uploader :image, MypageImageUploader
 
   has_many :projects, dependent: :destroy
+  has_many :assigned_cards, class_name: 'Card',
+                            foreign_key: :assignee_id,
+                            inverse_of: :assignee,
+                            dependent: :destroy
 
   attr_accessor :message
 

--- a/app/validators/due_date_range_validator.rb
+++ b/app/validators/due_date_range_validator.rb
@@ -1,0 +1,6 @@
+class DueDateRangeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.between?(Date.today, Date.today.next_year)
+    record.errors[attribute] << (options[:message] || 'は今日から1年後までの範囲で入力してください')
+  end
+end

--- a/app/views/cards/_form.html.slim
+++ b/app/views/cards/_form.html.slim
@@ -19,6 +19,11 @@
               .col-12.col-md-6
                 .form-group
                   = f.label :assignee_id
-                  = f.collection_select :assignee_id, User.all, :id, :name, { selected: project.user.id }, class: 'form-control form-control-lg'
+                  = f.collection_select :assignee_id, User.all, :id, :name, { selected: card.assignee.id }, class: 'form-control form-control-lg'
 
-            = f.submit '作成', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-4 width-200px'
+            - if card.new_record?
+              = f.submit '作成', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-4 width-200px'
+
+            -else
+              = f.submit '編集', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-4 width-200px'
+              = link_to '削除', project_column_card_path(project, column, card), method: :delete, data: { confirm: '本当に削除していいですか？' }, class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple width-100px mt-4 ml-1 ml-sm-2'

--- a/app/views/cards/_form.html.slim
+++ b/app/views/cards/_form.html.slim
@@ -1,0 +1,24 @@
+.row
+  .col-12.col-md-10.mx-auto.mt-4
+    .card.border-middle-purple.text-purple
+      .card-header.h3.bg-light-purple.pl-md-5 = title
+      .card-body.p-md-5
+        .card-text.h5
+          = form_with model:[project, column, card], local: true do |f|
+            .form-group
+              = f.label :name
+              = f.text_field :name, class: error_supported_field_class(instance: card, field: :name)
+              = render 'shared/form_errors', instance: card, field: :name
+
+            .row
+              .col-12.col-md-6
+                .form-group
+                  = f.label :due_date
+                  = f.date_field :due_date, type: 'date', class: error_supported_field_class(instance: card, field: :due_date), min: Date.today , max: Date.today.next_year, placeholder: 'yyyy-mm-dd（今日から1年後まで）', pattern: '^(20[0-9][0-9])-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+                  = render 'shared/form_errors', instance: card, field: :due_date
+              .col-12.col-md-6
+                .form-group
+                  = f.label :assignee_id
+                  = f.collection_select :assignee_id, User.all, :id, :name, { selected: project.user.id }, class: 'form-control form-control-lg'
+
+            = f.submit '作成', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-4 width-200px'

--- a/app/views/cards/edit.html.slim
+++ b/app/views/cards/edit.html.slim
@@ -1,0 +1,1 @@
+= render 'cards/form', project: @project, column: @column, card: @card, title: 'カードを編集'

--- a/app/views/cards/new.html.slim
+++ b/app/views/cards/new.html.slim
@@ -1,0 +1,1 @@
+= render 'cards/form', project: @project, column: @column, card: @card, title: 'カードを作成'

--- a/app/views/columns/_form.html.slim
+++ b/app/views/columns/_form.html.slim
@@ -15,4 +15,4 @@
 
             -else
               = f.submit '編集', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-4 width-200px'
-              = link_to '削除', project_column_path(project), method: :delete, data: { confirm: '本当に削除していいですか？' }, class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple width-100px mt-4 ml-1 ml-sm-2'
+              = link_to '削除', project_column_path(project, column), method: :delete, data: { confirm: '本当に削除していいですか？' }, class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple width-100px mt-4 ml-1 ml-sm-2'

--- a/app/views/projects/_card.html.slim
+++ b/app/views/projects/_card.html.slim
@@ -6,7 +6,7 @@
           i.far.fa-arrow-alt-circle-left.fa-lg
 
       .col.text-center.text-truncate.px-0
-        = link_to '#', class: 'link-unstyled' do
+        = link_to edit_project_column_card_path(project, column, card), class: 'link-unstyled' do
           .card.btn.btn-lg.btn-outline-secondary.bg-light-purple.text-middle-purple
             .card-body.text-truncate.p-0
               .card-text.h6 = card.name

--- a/app/views/projects/_card.html.slim
+++ b/app/views/projects/_card.html.slim
@@ -2,7 +2,7 @@
   .card-body.overflow-scroll.pt-3.pb-2
     .row
       .col-2.px-0.my-auto
-        = link_to '#', class: 'text-middle-purple hover-middle-purple' do
+        = link_to previous_project_column_card_path(project, column, card), class: arrow_class(column, :previous) do
           i.far.fa-arrow-alt-circle-left.fa-lg
 
       .col.text-center.text-truncate.px-0
@@ -12,7 +12,7 @@
               .card-text.h6 = card.name
 
       .col-2.text-right.px-0.my-auto
-        = link_to '#', class: 'text-middle-purple hover-middle-purple' do
+        = link_to next_project_column_card_path(project, column, card), class: arrow_class(column, :next) do
           i.far.fa-arrow-alt-circle-right.fa-lg
 
     .row.mt-2
@@ -21,4 +21,5 @@
           span.mr-2.align-bottom 期限:#{l card.due_date, format: :mmdd}
         - else
           span.mr-1.align-bottom 期限: 設定なし
+          
         = image_tag card.assignee.image, class: 'size35x35 rounded-circle'

--- a/app/views/projects/_card.html.slim
+++ b/app/views/projects/_card.html.slim
@@ -5,12 +5,11 @@
         = link_to '#', class: 'text-middle-purple hover-middle-purple' do
           i.far.fa-arrow-alt-circle-left.fa-lg
 
-      .col.text-center.overflow-scroll.px-0
-        a.link-unstyled href='#'
+      .col.text-center.text-truncate.px-0
+        = link_to '#', class: 'link-unstyled' do
           .card.btn.btn-lg.btn-outline-secondary.bg-light-purple.text-middle-purple
-            .card-body.overflow-scroll.p-0
-              .card-text.h6
-                |カード名
+            .card-body.text-truncate.p-0
+              .card-text.h6 = card.name
 
       .col-2.text-right.px-0.my-auto
         = link_to '#', class: 'text-middle-purple hover-middle-purple' do
@@ -18,5 +17,8 @@
 
     .row.mt-2
       .col.text-right
-        span.mr-2.align-bottom 期限: #{l Time.now, format: :mmdd}
-        = image_tag current_user.image, class: 'size35x35 rounded-circle'
+        - if card.due_date
+          span.mr-2.align-bottom 期限:#{l card.due_date, format: :mmdd}
+        - else
+          span.mr-1.align-bottom 期限: 設定なし
+        = image_tag card.assignee.image, class: 'size35x35 rounded-circle'

--- a/app/views/projects/_column.html.slim
+++ b/app/views/projects/_column.html.slim
@@ -16,7 +16,7 @@
             i.fas.fa-arrow-circle-right.fa-lg
 
     .card-body
-      - 4.times do
-        = render 'projects/card'
+      - column.cards.each do |card|
+        = render 'projects/card', card: card
 
-      = link_to 'カードを追加', '#', class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'
+      = link_to 'カードを追加', new_project_column_card_path(project, column), class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'

--- a/app/views/projects/_column.html.slim
+++ b/app/views/projects/_column.html.slim
@@ -17,6 +17,6 @@
 
     .card-body
       - column.cards.each do |card|
-        = render 'projects/card', card: card
+        = render 'projects/card', project: project, column: column, card: card
 
       = link_to 'カードを追加', new_project_column_card_path(project, column), class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module QuasiCase
     config.active_record.default_timezone = :local
 
     config.rack_dev_mark.enable = !Rails.env.production?
+
+    config.autoload_paths += Dir["#{config.root}/app/validators"]
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,10 @@ ja:
         summary: 概要
       column:
         name: カラム名
+      card:
+        name: カード名
+        due_date: 期限
+        assignee_id: 担当者
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -212,5 +216,7 @@ ja:
       default: "%Y/%m/%d %H:%M:%S"
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
-      mmdd: "%_m月%_d日"
     pm: 午後
+  date:
+    formats:
+      mmdd: "%_m月%_d日"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member
+      resources :cards, only: %i[new create]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member
-      resources :cards, only: %i[new create]
+      resources :cards, only: %i[new create edit update destroy]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,10 @@ Rails.application.routes.draw do
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member
-      resources :cards, only: %i[new create edit update destroy]
+      resources :cards, only: %i[new create edit update destroy] do
+        get 'previous', on: :member
+        get 'next', on: :member
+      end
     end
   end
 

--- a/db/migrate/20180514022821_create_cards.rb
+++ b/db/migrate/20180514022821_create_cards.rb
@@ -1,0 +1,14 @@
+class CreateCards < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cards do |t|
+      t.string :name, null: false
+      t.date :due_date
+      t.references :assignee, foreign_key: { to_table: :users }, null: false
+      t.references :project, foreign_key: true, null: false
+      t.references :column, foreign_key: true, null: false
+
+      t.timestamps
+    end
+    add_index  :cards, [:project_id, :name], unique: true
+  end
+end

--- a/db/migrate/20180515023307_add_position_to_card.rb
+++ b/db/migrate/20180515023307_add_position_to_card.rb
@@ -1,0 +1,5 @@
+class AddPositionToCard < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cards, :position, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180513050251) do
+ActiveRecord::Schema.define(version: 20180514022821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "cards", force: :cascade do |t|
+    t.string "name", null: false
+    t.date "due_date"
+    t.bigint "assignee_id", null: false
+    t.bigint "project_id", null: false
+    t.bigint "column_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assignee_id"], name: "index_cards_on_assignee_id"
+    t.index ["column_id"], name: "index_cards_on_column_id"
+    t.index ["project_id", "name"], name: "index_cards_on_project_id_and_name", unique: true
+    t.index ["project_id"], name: "index_cards_on_project_id"
+  end
 
   create_table "columns", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +59,9 @@ ActiveRecord::Schema.define(version: 20180513050251) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
+  add_foreign_key "cards", "columns"
+  add_foreign_key "cards", "projects"
+  add_foreign_key "cards", "users", column: "assignee_id"
   add_foreign_key "columns", "projects"
   add_foreign_key "projects", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180514022821) do
+ActiveRecord::Schema.define(version: 20180515023307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20180514022821) do
     t.bigint "column_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position", null: false
     t.index ["assignee_id"], name: "index_cards_on_assignee_id"
     t.index ["column_id"], name: "index_cards_on_column_id"
     t.index ["project_id", "name"], name: "index_cards_on_project_id_and_name", unique: true


### PR DESCRIPTION
ref #50 
カードの移動機能を作成しました。確認をお願いします。

- cards#previous、#nextのアクションとルートを作成
- ビューの対応（リンク作成など）
***
（カードの移動について補足）
例えばブラウザからurl直接入力で、先頭列のカラムにあるカードに対してcards#previousのパスが入力されたとしても、cards#previousの`@card.column = @column.higher_item`の結果`@card.column`にnilが入るため、その後の`@card.save`が失敗するので（falseが返るだけ）、何も起こりません。

対象コミット
d7f194b [add]カード移動機能を作成