### PR TITLE
プロジェクト参加機能を作成

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,6 +1,5 @@
 class CardsController < ApplicationController
-  before_action :set_host_project, only: %i[new create]
-  before_action :set_myproject, only: %i[edit update destroy previous next]
+  before_action :set_project
   before_action :set_column
   before_action :set_card, only: %i[edit update destroy previous next]
 
@@ -58,11 +57,7 @@ class CardsController < ApplicationController
     params.require(:card).permit(:name, :due_date, :assignee_id)
   end
 
-  def set_host_project
-    @project = current_user.projects.find(params[:project_id])
-  end
-
-  def set_myproject
+  def set_project
     @project = Project.accessible(current_user).find(params[:project_id])
   end
 

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,12 +1,11 @@
 class CardsController < ApplicationController
-  before_action :set_myproject, only: %i[new create]
-  before_action :set_project, only: %i[edit update destroy previous next]
+  before_action :set_host_project, only: %i[new create]
+  before_action :set_myproject, only: %i[edit update destroy previous next]
   before_action :set_column
   before_action :set_card, only: %i[edit update destroy previous next]
 
   def new
     @card = @column.cards.build
-    @card.project = @project
     @card.assignee = current_user
   end
 
@@ -59,11 +58,11 @@ class CardsController < ApplicationController
     params.require(:card).permit(:name, :due_date, :assignee_id)
   end
 
-  def set_myproject
+  def set_host_project
     @project = current_user.projects.find(params[:project_id])
   end
 
-  def set_project
+  def set_myproject
     @project = Project.accessible(current_user).find(params[:project_id])
   end
 

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -14,6 +14,12 @@ class MembershipsController < ApplicationController
     redirect_to project_path(@project), notice: "#{user.name}さんをプロジェクトに招待しました"
   end
 
+  def update
+    membership = current_user.memberships.find(params[:id])
+    membership.join!
+    redirect_to project_path(membership.project), notice: 'プロジェクトに参加しました'
+  end
+
   private
 
   def set_project

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,4 +1,22 @@
 class MembershipsController < ApplicationController
+  before_action :set_project, only: %i[create]
+
   def index
+    @memberships = Membership.where(user: current_user, join: false)
+                             .includes(project: :user)
+                             .order(created_at: :desc)
+                             .page(params[:page])
+  end
+
+  def create
+    user = User.find(params[:user_id])
+    @project.invite!(user)
+    redirect_to project_path(@project), notice: "#{user.name}さんをプロジェクトに招待しました"
+  end
+
+  private
+
+  def set_project
+    @project = current_user.projects.find(params[:project_id])
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,4 @@
+class MembershipsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,5 @@
 class ProjectsController < ApplicationController
-  before_action :set_project, only: %i[edit update destroy]
+  before_action :set_project, only: %i[edit update destroy invite]
 
   def index
     if request.path == myprojects_path
@@ -45,6 +45,9 @@ class ProjectsController < ApplicationController
       flash.now[:alert] = 'プロジェクトの削除に失敗しました。'
       render :edit
     end
+  end
+
+  def invite
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -48,6 +48,7 @@ class ProjectsController < ApplicationController
   end
 
   def invite
+    @users = User.search(params[:keyword]) if params[:keyword].present?
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to login_path, notice: 'アカウント情報を更新しました'
+      redirect_to root_path, notice: 'アカウント情報を更新しました'
     else
       render :edit
     end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -14,4 +14,12 @@ module FormHelper
       'btn btn-lg btn-block btn-secondary bg-light-purple border-middle-purple text-middle-purple mt-2 mt-lg-4'
     end
   end
+
+  def user_search_message(keyword, users)
+    if keyword.blank?
+      'ユーザ名を入力してください'
+    elsif users.blank?
+      '該当するユーザ名がありません'
+    end
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -2,9 +2,13 @@ class Membership < ApplicationRecord
   belongs_to :project
   belongs_to :user
 
+  has_one :project_user, through: :project, source: :user
+
   validates :project_id, uniqueness: { scope: :user_id }
 
   before_save :excludes_host_user
+
+  paginates_per 5
 
   private
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -10,6 +10,11 @@ class Membership < ApplicationRecord
 
   paginates_per 5
 
+  def join!
+    raise '既にプロジェクトに参加しています' if join
+    update!(join: true)
+  end
+
   private
 
   def excludes_host_user

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,14 @@
+class Membership < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+
+  validates :project_id, uniqueness: { scope: :user_id }
+
+  before_save :excludes_host_user
+
+  private
+
+  def excludes_host_user
+    throw(:abort) if project.host_user?(user)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,6 +2,8 @@ class Project < ApplicationRecord
   belongs_to :user
   has_many :columns, -> { order(position: :asc) }, dependent: :destroy
   has_many :cards, dependent: :destroy
+  has_many :memberships, dependent: :destroy
+  has_many :members, through: :memberships, source: :user
 
   COUNT_FOR_FIRST_PAGE = 8
   COUNT_FOR_OTHER_PAGE = 9

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,4 +42,12 @@ class Project < ApplicationRecord
   def host_user?(user)
     user == self.user
   end
+
+  def member_user?(user)
+    members.exists?(id: user.id)
+  end
+
+  def invite!(user)
+    Membership.create!(project: self, user: user)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,10 @@ class User < ApplicationRecord
     where('name LIKE ?', "%#{sanitize_sql_like(keyword)}%")
   end
 
+  def notifications_count
+    Membership.where(user: self, join: false).count
+  end
+
   after_find do
     @message = 'ログインしました'
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
                             foreign_key: :assignee_id,
                             inverse_of: :assignee,
                             dependent: :destroy
+  has_many :memberships, dependent: :destroy
+  has_many :member_projects, through: :memberships, source: :project
 
   attr_accessor :message
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,10 @@ class User < ApplicationRecord
     end
   end
 
+  scope :search, ->(keyword) do
+    where('name LIKE ?', "%#{sanitize_sql_like(keyword)}%")
+  end
+
   after_find do
     @message = 'ログインしました'
   end

--- a/app/views/memberships/_notifications.html.slim
+++ b/app/views/memberships/_notifications.html.slim
@@ -1,0 +1,8 @@
+- memberships.each do |membership|
+  li.list-group-item.pl-md-5.pr-md-5
+    .row.align-items-center.my-0.my-md-1
+      .col-auto.pr-0
+        = image_tag membership.project_user.image, class: 'size35x35 rounded-circle'
+      .col #{membership.project_user.name}さんが#{membership.project.name}プロジェクトに招待しています
+      .col-auto
+        = link_to '参加', '#', class: 'btn btn-outline-secondary bg-light-purple text-middle-purple border-middle-purple'

--- a/app/views/memberships/_notifications.html.slim
+++ b/app/views/memberships/_notifications.html.slim
@@ -5,4 +5,4 @@
         = image_tag membership.project_user.image, class: 'size35x35 rounded-circle'
       .col #{membership.project_user.name}さんが#{membership.project.name}プロジェクトに招待しています
       .col-auto
-        = link_to '参加', '#', class: 'btn btn-outline-secondary bg-light-purple text-middle-purple border-middle-purple'
+        = link_to '参加', membership_path(membership),method: :patch, class: 'btn btn-outline-secondary bg-light-purple text-middle-purple border-middle-purple'

--- a/app/views/memberships/_notifications_view_more.html.slim
+++ b/app/views/memberships/_notifications_view_more.html.slim
@@ -1,0 +1,3 @@
+- unless memberships.last_page?
+  .card-footer.text-center.bg-white
+    = link_to_next_page memberships, 'もっと見る', class: 'btn btn-lg btn-outline-secondary width-250px', remote: true

--- a/app/views/memberships/index.html.slim
+++ b/app/views/memberships/index.html.slim
@@ -1,0 +1,18 @@
+.row
+  .col-12.col-md-10.mx-auto.mt-4
+    .card.border-middle-purple.text-purple
+      .card-header.h3.bg-light-purple.pl-md-5 お知らせ
+      ul.list-group.list-group-flush.text-middle-purple.h4
+
+        - 5.times do
+          li.list-group-item.pl-md-5.pr-md-5
+            .row.align-items-center.my-0.my-md-1
+              .col-auto.pr-0
+                = image_tag current_user.image, class: 'size35x35 rounded-circle'
+              .col
+                |#{current_user.name}さんが#{current_user.projects.first.name}プロジェクトに招待しています
+              .col-auto
+                = link_to '参加', '#', class: 'btn btn-outline-secondary bg-light-purple text-middle-purple border-middle-purple'
+
+      .card-footer.text-center.bg-white
+        = link_to 'もっと見る', '#', class: 'btn btn-lg btn-outline-secondary width-250px'

--- a/app/views/memberships/index.html.slim
+++ b/app/views/memberships/index.html.slim
@@ -2,17 +2,15 @@
   .col-12.col-md-10.mx-auto.mt-4
     .card.border-middle-purple.text-purple
       .card-header.h3.bg-light-purple.pl-md-5 お知らせ
-      ul.list-group.list-group-flush.text-middle-purple.h4
 
-        - 5.times do
-          li.list-group-item.pl-md-5.pr-md-5
-            .row.align-items-center.my-0.my-md-1
-              .col-auto.pr-0
-                = image_tag current_user.image, class: 'size35x35 rounded-circle'
-              .col
-                |#{current_user.name}さんが#{current_user.projects.first.name}プロジェクトに招待しています
-              .col-auto
-                = link_to '参加', '#', class: 'btn btn-outline-secondary bg-light-purple text-middle-purple border-middle-purple'
+      - if @memberships.present?
+        ul.list-group.list-group-flush.text-middle-purple.h4
+          #js-notifications
+            = render 'memberships/notifications', memberships: @memberships
 
-      .card-footer.text-center.bg-white
-        = link_to 'もっと見る', '#', class: 'btn btn-lg btn-outline-secondary width-250px'
+        #js-notifications_view_more
+          = render 'memberships/notifications_view_more', memberships: @memberships
+
+      - else
+        .card-body.pl-md-5
+          .card-text.h4 お知らせはありません

--- a/app/views/memberships/index.js.erb
+++ b/app/views/memberships/index.js.erb
@@ -1,0 +1,2 @@
+$("#js-notifications").append("<%= j(render 'memberships/notifications', memberships: @memberships) %>");
+$("#js-notifications_view_more").html("<%= j(render 'memberships/notifications_view_more', memberships: @memberships) %>");

--- a/app/views/projects/_column.html.slim
+++ b/app/views/projects/_column.html.slim
@@ -19,4 +19,5 @@
       - column.cards.each do |card|
         = render 'projects/card', project: project, column: column, card: card
 
-      = link_to 'カードを追加', new_project_column_card_path(project, column), class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'
+      - if project.host_user?(current_user)
+        = link_to 'カードを追加', new_project_column_card_path(project, column), class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'

--- a/app/views/projects/_column.html.slim
+++ b/app/views/projects/_column.html.slim
@@ -19,5 +19,4 @@
       - column.cards.each do |card|
         = render 'projects/card', project: project, column: column, card: card
 
-      - if project.host_user?(current_user)
-        = link_to 'カードを追加', new_project_column_card_path(project, column), class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'
+      = link_to 'カードを追加', new_project_column_card_path(project, column), class: 'btn btn-sm btn-outline-secondary border-middle-purple text-middle-purple my-2'

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -4,7 +4,7 @@
       .card-header.h3.bg-light-purple.pl-md-5 = title
       .card-body.p-md-5
         .card-text.h5
-          = form_with model:project, local: true do |f|
+          = form_with model: project, local: true do |f|
             .form-group
               = f.label :name
               = f.text_field :name, class: error_supported_field_class(instance: project, field: :name)

--- a/app/views/projects/invite.html.slim
+++ b/app/views/projects/invite.html.slim
@@ -1,0 +1,14 @@
+.row
+  .col-12.col-md-10.mx-auto.mt-4
+    .card.border-middle-purple.text-purple
+      .card-header.h3.bg-light-purple.pl-md-5 ユーザを招待
+      .card-body.p-md-5
+        .card-text.h5
+          = form_with url: '#', method: :get, local: true do |f|
+          
+            p.mb-2 ユーザを検索
+            .row
+              .col-11.col-sm-7.pr-0
+                = f.text_field :keyword, class: 'form-control form-control-lg', placeholder: 'ユーザ名'
+              .col-auto.mt-2.mt-sm-0.pl-3.pl-sm-2
+                = f.submit '検索', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple width-150px'

--- a/app/views/projects/invite.html.slim
+++ b/app/views/projects/invite.html.slim
@@ -22,7 +22,12 @@
               .row.mt-4.align-items-center
                 .col-auto = image_tag user.image, class: 'size35x35 rounded-circle'
                 .col-5.col-md-4.col-lg-3.px-0.h4.mb-0 = user.name
-                - if user == current_user
-                  .col-auto.width-120px.text-middle-purple.text-center.ml-1.mt-1.mt-sm-0 自分
-                - else
-                  = link_to '招待', '#', class: 'col-auto btn btn-lg btn-outline-secondary border-middle-purple text-middle-purple width-120px ml-1 mt-1 mt-sm-0'
+
+                - if @project.host_user?(user)
+                  .col-auto.width-120px.text-middle-purple.text-center.font-weight-bold.ml-1.mt-1.mt-sm-0 ホスト
+
+                - elsif @project.member_user?(user)
+                  .col-auto.width-120px.text-middle-purple.text-center.ml-1.mt-1.mt-sm-0 招待済み
+
+                -else
+                  = link_to '招待', memberships_path(project_id: @project.id, user_id: user.id), method: :post, class: 'col-auto btn btn-lg btn-outline-secondary border-middle-purple text-middle-purple width-120px ml-1 mt-1 mt-sm-0'

--- a/app/views/projects/invite.html.slim
+++ b/app/views/projects/invite.html.slim
@@ -4,11 +4,25 @@
       .card-header.h3.bg-light-purple.pl-md-5 ユーザを招待
       .card-body.p-md-5
         .card-text.h5
-          = form_with url: '#', method: :get, local: true do |f|
-          
+          = form_with url: invite_project_path(@project), method: :get, local: true do |f|
+
             p.mb-2 ユーザを検索
             .row
               .col-11.col-sm-7.pr-0
-                = f.text_field :keyword, class: 'form-control form-control-lg', placeholder: 'ユーザ名'
-              .col-auto.mt-2.mt-sm-0.pl-3.pl-sm-2
-                = f.submit '検索', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple width-150px'
+                = f.text_field :keyword, class: 'form-control form-control-lg', placeholder: 'ユーザ名（一部でも可）', value: params[:keyword].presence
+
+                - unless params[:keyword].nil?
+                  .mt-2.text-secondary-purple = user_search_message(params[:keyword], @users)
+
+              .col-auto.pl-3.pl-sm-2
+                = f.submit '検索', class: 'btn btn-lg btn-secondary bg-light-purple border-middle-purple text-middle-purple width-150px mb-5'
+
+          - if @users
+            - @users.each do |user|
+              .row.mt-4.align-items-center
+                .col-auto = image_tag user.image, class: 'size35x35 rounded-circle'
+                .col-5.col-md-4.col-lg-3.px-0.h4.mb-0 = user.name
+                - if user == current_user
+                  .col-auto.width-120px.text-middle-purple.text-center.ml-1.mt-1.mt-sm-0 自分
+                - else
+                  = link_to '招待', '#', class: 'col-auto btn btn-lg btn-outline-secondary border-middle-purple text-middle-purple width-120px ml-1 mt-1 mt-sm-0'

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -2,11 +2,13 @@
   .col-md-7.col-lg-8.col-xl-9.overflow-scroll
     .h4.text-middle-purple = @project.name
   .col-md-5.col-lg-4.col-xl-3.text-right.pr-3
+    - if @project.accessible?(current_user)
       = link_to 'ログを見る', '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-2'
-      = link_to 'ユーザを招待', '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple'
+    - if @project.host_user?(current_user)
+      = link_to 'ユーザを招待', invite_project_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple'
 
 .row.mt-4.text-middle-purple.row-scroll-x.w-100.pb-2
-  
+
   - @project.columns.each do |column|
     = render 'projects/column', project: @project, column: column
 

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -2,8 +2,7 @@
   .col-md-7.col-lg-8.col-xl-9.overflow-scroll
     .h4.text-middle-purple = @project.name
   .col-md-5.col-lg-4.col-xl-3.text-right.pr-3
-    - if @project.accessible?(current_user)
-      = link_to 'ログを見る', '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-2'
+    = link_to 'ログを見る', '#', class: 'btn btn-outline-secondary border-middle-purple text-middle-purple mr-2'
     - if @project.host_user?(current_user)
       = link_to 'ユーザを招待', invite_project_path(@project), class: 'btn btn-outline-secondary border-middle-purple text-middle-purple'
 

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,7 +14,7 @@ header.header
           - if logged_in?
             li.nav-item
               h5.my-0.my-sm-1
-                = link_to '0', notifications_path, class: 'badge badge-light'
+                = link_to current_user.notifications_count, notifications_path, class: 'badge badge-light'
 
             li.nav-item.mt-2.mt-sm-0.ml-0.ml-sm-1.ml-md-3
               = link_to mypage_path do

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,8 +14,8 @@ header.header
           - if logged_in?
             li.nav-item
               h5.my-0.my-sm-1
-                span.badge.badge-light
-                  | 0
+                = link_to '0', notifications_path, class: 'badge badge-light'
+
             li.nav-item.mt-2.mt-sm-0.ml-0.ml-sm-1.ml-md-3
               = link_to mypage_path do
                 = image_tag current_user.image, class: 'size35x35 rounded-circle'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,6 @@ Rails.application.routes.draw do
   end
 
   get 'myprojects', to: 'projects#index'
+
+  get 'notifications', to: 'memberships#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,12 @@ Rails.application.routes.draw do
   delete 'mypage', to: 'users#destroy'
 
   resources :projects do
+    get 'invite', on: :member
+
     resources :columns, only: %i[new create edit update destroy] do
       get 'previous', on: :member
       get 'next', on: :member
+
       resources :cards, only: %i[new create edit update destroy] do
         get 'previous', on: :member
         get 'next', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,5 @@ Rails.application.routes.draw do
   get 'myprojects', to: 'projects#index'
 
   get 'notifications', to: 'memberships#index'
+  resources :memberships, only: %i[create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,5 +29,5 @@ Rails.application.routes.draw do
   get 'myprojects', to: 'projects#index'
 
   get 'notifications', to: 'memberships#index'
-  resources :memberships, only: %i[create]
+  resources :memberships, only: %i[create update]
 end

--- a/db/migrate/20180518014342_create_memberships.rb
+++ b/db/migrate/20180518014342_create_memberships.rb
@@ -1,0 +1,12 @@
+class CreateMemberships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :memberships do |t|
+      t.references :project, foreign_key: { on_delete: :cascade }, null: false
+      t.references :user, foreign_key: { on_delete: :cascade }, null: false
+      t.boolean :join, null: false, default: false
+
+      t.timestamps
+    end
+    add_index :memberships, [:project_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180515023307) do
+ActiveRecord::Schema.define(version: 20180518014342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,17 @@ ActiveRecord::Schema.define(version: 20180515023307) do
     t.index ["project_id"], name: "index_columns_on_project_id"
   end
 
+  create_table "memberships", force: :cascade do |t|
+    t.bigint "project_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "join", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "user_id"], name: "index_memberships_on_project_id_and_user_id", unique: true
+    t.index ["project_id"], name: "index_memberships_on_project_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
   create_table "projects", force: :cascade do |t|
     t.string "name", null: false
     t.text "summary"
@@ -64,5 +75,7 @@ ActiveRecord::Schema.define(version: 20180515023307) do
   add_foreign_key "cards", "projects"
   add_foreign_key "cards", "users", column: "assignee_id"
   add_foreign_key "columns", "projects"
+  add_foreign_key "memberships", "projects", on_delete: :cascade
+  add_foreign_key "memberships", "users", on_delete: :cascade
   add_foreign_key "projects", "users"
 end

--- a/frontend/stylesheets/modules/sizes.scss
+++ b/frontend/stylesheets/modules/sizes.scss
@@ -14,6 +14,10 @@
   width: 200px;
 }
 
+.width-150px {
+  width: 150px;
+}
+
 .width-100px {
   width: 100px;
 }

--- a/frontend/stylesheets/modules/sizes.scss
+++ b/frontend/stylesheets/modules/sizes.scss
@@ -18,6 +18,10 @@
   width: 150px;
 }
 
+.width-120px {
+  width: 120px;
+}
+
 .width-100px {
   width: 100px;
 }


### PR DESCRIPTION
ref #58 
プロジェクト参加機能を作成しました。確認をお願いいたします。

- memberships#updateアクション、ルートを作成（参加する＝membershipsのjoinカラムをtrueに更新する）
（※ membershipモデルのjoin!メソッドで、既に参加済みのメンバーが参加した場合はエラーになるよう設定）
（※ワイヤーフレームのお知らせ画面に「表示したら既読したことにする」とありましたが、「参加したら既読したことにする」と読み替えました。問題があればご指摘ください。）

- 権限関係の整理（projectモデルのaccessibleスコープとaccessible?メソッドを修正）
***
（権限は以下の設定にしています）
※権限ユーザ＝プロジェクト参加済みユーザ

project一覧：（全プロジェクトの表示）権限なし／（マイプロジェクトの表示）参加プロジェクトのみ
project詳細：権限ユーザ
project作成：権限なし
project編集：ホストユーザ
project削除：ホストユーザ

projectに招待：ホストユーザ

column作成：権限ユーザ
column編集：権限ユーザ
column削除：権限ユーザ
column移動：権限ユーザ

~~card作成：ホストユーザ~~
card作成：権限ユーザ
card編集：権限ユーザ
card削除：権限ユーザ
card移動：権限ユーザ

~~※「card作成」に関しては、F01-01で「プロジェクトを作成したユーザーだけが作成可能」とあり、今回のG01-05では「参加ユーザはカラム、カードの作成編集削除はできる」とあり、権限を結局どう設定すればよいかわからなかったので、とりあえずホストユーザのみにしました。問題あれば対応しますので、ご指摘お願いします。~~
card作成も権限ユーザにしました 2c093b7

※権限のないユーザがurl直接入力などで権限のないページを表示しようとしても、ActiveRecord::RecordNotFoundで404エラーが表示されるように設定しています。
（厳密に言えば403閲覧禁止が正しいかもしれないのですが、今回の仕様では権限のないページに遷移する導線がアプリに無いため、該当ページがないという意味で404エラーで表示しても問題ないと考えました。※githubなどと同じ動作です。）

対象コミット
8726d72 [add]プロジェクト参加機能を作成
2c093b7 [change]カード作成の権限を変更