### PR TITLE
退会した時のハンドリングを作成

### DIFF
--- a/app/callbacks/column_logs_callbacks.rb
+++ b/app/callbacks/column_logs_callbacks.rb
@@ -11,6 +11,7 @@ class ColumnLogsCallbacks
   end
 
   def after_destroy(column)
+    return if column.operator.nil?
     content = "#{column.operator.name}さんが#{column.name}カラムを削除しました"
     Log.create!(content: content, project: column.project)
   end

--- a/app/callbacks/membership_logs_callbacks.rb
+++ b/app/callbacks/membership_logs_callbacks.rb
@@ -9,4 +9,10 @@ class MembershipLogsCallbacks
     content = "#{membership.user.name}さんがこのプロジェクトに参加しました"
     Log.create!(content: content, project: membership.project)
   end
+
+  def after_destroy(membership)
+    return unless membership.join
+    content = "メンバーの#{membership.user.name}さんがプロジェクトから退会しました"
+    Log.create!(content: content, project: membership.project)
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -9,6 +9,7 @@ class Membership < ApplicationRecord
   before_save :excludes_host_user
   after_create MembershipLogsCallbacks.new
   after_update MembershipLogsCallbacks.new
+  after_destroy MembershipLogsCallbacks.new
 
   paginates_per 5
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,6 +30,10 @@ class Project < ApplicationRecord
     end
   end
 
+  scope :having_participants, -> do
+    joins(:memberships).where(memberships: { join: true }).distinct
+  end
+
   scope :accessible, ->(user) do
     relation = Project.left_joins(:memberships)
     relation.merge(Membership.where(user: user, join: true))
@@ -50,5 +54,13 @@ class Project < ApplicationRecord
 
   def invite!(user)
     Membership.create!(project: self, user: user)
+  end
+
+  def change_host
+    oldest_membersip = memberships.where(join: true).order(updated_at: :asc).first
+    oldest_member = oldest_membersip.user
+
+    oldest_membersip.delete
+    update(user: oldest_member)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,9 +35,10 @@ class Project < ApplicationRecord
   end
 
   scope :accessible, ->(user) do
-    relation = Project.left_joins(:memberships)
-    relation.merge(Membership.where(user: user, join: true))
-            .or(relation.where(user: user))
+    joined_table = Project.left_joins(:memberships)
+    joined_table.merge(Membership.where(user: user, join: true))
+            .or(joined_table.where(user: user))
+            .distinct
   end
 
   def accessible?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
 
   validates :name, presence: true
 
+  before_destroy :handles_projects, prepend: true
+
   def self.find_or_create_from_auth(auth)
     provider = auth[:provider]
     uid = auth[:uid]
@@ -41,17 +43,15 @@ class User < ApplicationRecord
     @message = 'アカウント登録しました'
   end
 
-  def destroy
-    # ホストが退会するプロジェクトに参加者がいる場合は、ホストを交代する
+  private
+
+  # ホストが退会するプロジェクトに参加者がいる場合は、ホストを交代する
+  def handles_projects
     target_projects = projects.having_participants
     if target_projects.present?
       manages_accounts_in(target_projects)
     end
-
-    super
   end
-
-  private
 
   def manages_accounts_in(projects)
     projects.each do |project|


### PR DESCRIPTION
ref #67 
退会した時のハンドリングを作成しました。確認をお願いします。
~~- userモデルのdestroyメソッドをオーバーライドして、退会処理を追加~~
~~04a2926 [add]退会処理を作成~~
→上記 04a2926 の退会処理を修正して、userモデルのbefore_destroyコールバックに退会処理を移動した 0c8d0b0
（※当初コールバックの処理がうまく行かなかったのですが、before_destroyに`prepend: true`オプションを忘れていただけでした！）

---
※これまでのコードにバグが見つかったため修正

6e28db6[fix] カラムのログを修正
→プロジェクトが削除されて関連カラムが自動削除される際に、カラムに関するログを生成しないよう修正
（上記の場合のログ生成処理で、作業者column.operatorがnilなのでエラーになってしまっていた）

fcef5ab [fix]projectモデルのスコープを修正
→スコープaccessibleの検索結果から重複を取り除くよう修正
（検索用のjoind_tableを作って検索をした後で、最後に重複を取り除かなかったため検索結果が重複してしまっていた）

---
（対象コミット）
6e28db6 [fix]カラムのログを修正
04a2926 [add]退会処理を作成
fcef5ab [fix]projectモデルのスコープを修正
0c8d0b0 [clean]退会処理の記述をコールバックに移動